### PR TITLE
[293] Fixed In /user/lang incorrect response 403 Forbidden to 401 Unauthorized

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -599,10 +599,13 @@ public class UserController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     @GetMapping("/lang")
     public ResponseEntity<String> getUserLang(@ApiIgnore @CurrentUser UserVO userVO) {
+        if (userVO == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
         return ResponseEntity.status(HttpStatus.OK).body(userVO.getLanguageVO().getCode());
     }
 

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -527,6 +527,20 @@ class UserControllerTest {
     }
 
     @Test
+    void getUserLangUnauthorized() throws Exception {
+        Principal principal = mock(Principal.class);
+
+        when(principal.getName()).thenReturn(TestConst.EMAIL);
+        when(userService.findByEmail(principal.getName())).thenReturn(null);
+
+        this.mockMvc.perform(get(userLink + "/lang")
+                        .principal(principal))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("Unauthorized"));
+    }
+
+
+    @Test
     void getReasonsOfDeactivation() throws Exception {
         List<String> test = List.of("test", "test");
         when(userService.getDeactivationReason(1L, "en")).thenReturn(test);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved error handling for unauthorized user language retrieval
    - Updated response status to correctly indicate unauthorized access (401 Unauthorized)

- **Tests**
    - Added test case to verify unauthorized access handling for user language endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->