### PR TITLE
Issue #215 resolved on sending invalid request to /email/sendHabitNotification end-point and getting status 400 in such case

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
@@ -167,7 +173,11 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -4,6 +4,7 @@ import greencity.constant.HttpStatuses;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.violation.UserViolationMailDto;
+import greencity.exception.handler.ValidationExceptionDto;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
@@ -11,11 +12,17 @@ import greencity.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/email")
@@ -71,7 +78,17 @@ public class EmailController {
      * @author Taras Kavkalo
      */
     @PostMapping("/sendHabitNotification")
-    public ResponseEntity<Object> sendHabitNotification(@RequestBody SendHabitNotification sendHabitNotification) {
+    public ResponseEntity<Object> sendHabitNotification(@RequestBody @Valid SendHabitNotification sendHabitNotification,
+                                                        BindingResult bindingResult) {
+
+        if(bindingResult.hasErrors()) {
+
+            List<ValidationExceptionDto> validationExceptionDtoList = new ArrayList<>();
+            bindingResult.getFieldErrors().forEach(err->validationExceptionDtoList
+                    .add(new ValidationExceptionDto(err)));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationExceptionDtoList);
+        }
+
         emailService.sendHabitNotification(sendHabitNotification.getName(), sendHabitNotification.getEmail());
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -412,7 +412,11 @@ public class UserController {
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })
     @GetMapping("/findByEmail")
-    public ResponseEntity<UserVO> findByEmail(@RequestParam String email) {
+    public ResponseEntity<?> findByEmail(@RequestParam  String email) {
+
+        if (!email.matches("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Your entered email has invalid format!");
+        }
         return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
     }
 

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -414,10 +414,16 @@ public class UserController {
     @GetMapping("/findByEmail")
     public ResponseEntity<?> findByEmail(@RequestParam  String email) {
 
+        // # issue 274, returning bad request in case of malformed email
         if (!email.matches("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Your entered email has invalid format!");
         }
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
+        // #issue 27, returning status 404 in case of having not found a user with a given email
+        UserVO foundUserV0 = userService.findByEmail(email);
+        if(foundUserV0 == null){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User with email: "+email+" does not exist !");
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(foundUserV0);
     }
 
     /**

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EmailControllerTest {
     private static final String LINK = "/email";
     private MockMvc mockMvc;
@@ -169,6 +172,40 @@ class EmailControllerTest {
             verify(emailService, times(0)).sendHabitNotification(anyString(), anyString());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "Joe Doe, Test1@gmail.com, 200",
+            "'','',400",
+            "1111, validemail@gmail.com, 400",
+            "Joe, Test1@mail..com, 400",
+            "1111, Test1mail.com, 400",
+            "'', Test1@gmail.com, 400",
+            "Joe Doe, '', 400"
+    })
+    void testSendHabitNotificationStatuses200And400(String name, String email, int expectedStatus) throws Exception {
+
+        Principal principal = ()->"test@test.com";
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
+
+        if(expectedStatus ==200) {
+            when(userService.findByEmail("Test1@gmail.com")).thenReturn(new UserVO());
+            doNothing().when(emailService).sendHabitNotification(name, email);
+        }
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().is(expectedStatus))
+                .andDo(print());
+
+        if(expectedStatus == 200)
+            verify(emailService, times(1)).sendHabitNotification(name, email);
+        else
+            verify(emailService, times(0)).sendHabitNotification(anyString(), anyString());
+    }
+
 
     private void mockPerform(String content, String subLink) throws Exception {
         mockMvc.perform(post(LINK + subLink)
@@ -176,6 +213,8 @@ class EmailControllerTest {
             .content(content))
             .andExpect(status().isOk());
     }
+
+
 
     @Test
     void sendUserViolationEmailTest() throws Exception {

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.notification.NotificationDto;
+import greencity.dto.user.UserVO;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
 import greencity.service.EmailService;
+import greencity.service.UserService;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,10 +25,10 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import java.security.Principal;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,6 +40,9 @@ class EmailControllerTest {
 
     @Mock
     private EmailService emailService;
+
+    @Mock
+    private UserService userService;
 
     @InjectMocks
     private EmailController emailController;
@@ -142,9 +147,17 @@ class EmailControllerTest {
     })
     void sendHabitNotification(String name, String email, int expectedStatus) throws Exception {
 
+        Principal principal = ()->"test@test.com";
+
         String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
 
+        if(expectedStatus ==200) {
+            when(userService.findByEmail("Test1@gmail.com")).thenReturn(new UserVO());
+            doNothing().when(emailService).sendHabitNotification(name, email);
+        }
+
         mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .principal(principal)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().is(expectedStatus))

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -14,6 +14,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,9 +23,12 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -124,6 +129,33 @@ class EmailControllerTest {
 
         verify(emailService).sendHabitNotification(notification.getName(), notification.getEmail());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Joe Doe, Test1@gmail.com, 200",
+            "'','',400",
+            "1111, validemail@gmail.com, 400",
+             "Joe, Test1@mail..com, 400",
+            "1111, Test1mail.com, 400",
+            "'', Test1@gmail.com, 400",
+            "Joe Doe, '', 400"
+    })
+    void sendHabitNotification(String name, String email, int expectedStatus) throws Exception {
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().is(expectedStatus))
+                .andDo(print());
+
+        if(expectedStatus == 200)
+            verify(emailService, times(1)).sendHabitNotification(name, email);
+        else
+            verify(emailService, times(0)).sendHabitNotification(anyString(), anyString());
+    }
+
 
     private void mockPerform(String content, String subLink) throws Exception {
         mockMvc.perform(post(LINK + subLink)

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -406,6 +406,18 @@ class UserControllerTest {
     }
 
     @Test
+    void findByEmailTestReturns404() throws Exception {
+
+        String notExistedEmail="124125@gmail.com";
+
+        mockMvc.perform(get(userLink + "/findByEmail")
+                        .param("email", notExistedEmail))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+
+    }
+
+    @Test
     void findByIdTest() throws Exception {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findById(1L)).thenReturn(userVO);

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -57,13 +57,16 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -391,6 +394,18 @@ class UserControllerTest {
     }
 
     @Test
+    void findByEmailTestReturns400() throws Exception {
+
+        String malformedEmail="124125gmail.com";
+
+        mockMvc.perform(get(userLink + "/findByEmail")
+                        .param("email", malformedEmail))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+    }
+
+    @Test
     void findByIdTest() throws Exception {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findById(1L)).thenReturn(userVO);
@@ -470,7 +485,7 @@ class UserControllerTest {
             .principal(principal)
             .content(objectMapper.writeValueAsString(ModelUtils.getUserVO())))
             .andExpect(status().isOk())
-            .andDo(MockMvcResultHandlers.print())
+            .andDo(print())
             .andExpect(jsonPath("$.uuid").value("testUuid"));
 
     }

--- a/service-api/src/main/java/greencity/message/SendHabitNotification.java
+++ b/service-api/src/main/java/greencity/message/SendHabitNotification.java
@@ -18,8 +18,7 @@ import lombok.ToString;
 public class SendHabitNotification implements Serializable {
 
     @NotBlank(message = "Name must not be blank")
-    @Pattern(regexp = "^[\\p{L}'][\\p{L}' -]*[\\p{L}']$", message = "Name must contain valid characters and spaces")
-    @Size(min = 2, message = "Name should contain at least two letters")
+    @Pattern(regexp = "^[A-Za-z\\s-'`]+$", message = "Name must contain valid characters and spaces")
     private String name;
 
     @Email(message = "Email must have a correct format")

--- a/service-api/src/main/java/greencity/message/SendHabitNotification.java
+++ b/service-api/src/main/java/greencity/message/SendHabitNotification.java
@@ -1,9 +1,8 @@
 package greencity.message;
 
 import java.io.Serializable;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +18,8 @@ import lombok.ToString;
 public class SendHabitNotification implements Serializable {
 
     @NotBlank(message = "Name must not be blank")
-    @Pattern(regexp = "^[a-zA-Z ]+$", message = "Name must contain only alphabetic characters and spaces")
+    @Pattern(regexp = "^[\\p{L}'][\\p{L}' -]*[\\p{L}']$", message = "Name must contain valid characters and spaces")
+    @Size(min = 2, message = "Name should contain at least two letters")
     private String name;
 
     @Email(message = "Email must have a correct format")

--- a/service-api/src/main/java/greencity/message/SendHabitNotification.java
+++ b/service-api/src/main/java/greencity/message/SendHabitNotification.java
@@ -1,6 +1,9 @@
 package greencity.message;
 
 import java.io.Serializable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +17,12 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SendHabitNotification implements Serializable {
+
+    @NotBlank(message = "Name must not be blank")
+    @Pattern(regexp = "^[a-zA-Z ]+$", message = "Name must contain only alphabetic characters and spaces")
     private String name;
+
+    @Email(message = "Email must have a correct format")
+    @NotBlank(message = "Email must not be blank")
     private String email;
 }


### PR DESCRIPTION
Issue 215 about validating data given by user to /email/sendHabitNotification and returning 400 in such cases has been resolved, with screenshots being added 

Link to issue: https://github.com/Board-Project-Stage/ProjectStage_January/issues/215

<img width="655" alt="Screenshot 2025-01-17 at 21 22 07" src="https://github.com/user-attachments/assets/2539b750-dedb-4bc0-bae3-d427ee9201ed" />
<img width="1279" alt="Screenshot 2025-01-17 at 21 22 56" src="https://github.com/user-attachments/assets/7a5dc081-b430-4b38-9df7-44b7a0fcd76d" />

<img width="1373" alt="Screenshot 2025-01-17 at 21 24 22" src="https://github.com/user-attachments/assets/130059e8-400a-45b8-b690-86a8fab2a902" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added validation for habit notification emails.
  - Enhanced user email retrieval with improved error handling.

- **Bug Fixes**
  - Improved input validation for email and habit notification requests.
  - Added specific error responses for invalid email formats and non-existent users.

- **Testing**
  - Expanded test coverage for email and user controller endpoints.
  - Added parameterized tests for various input scenarios.

- **Dependencies**
  - Updated project dependencies, including JUnit Jupiter and Commons Validator.
  - Removed Hamcrest dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->