### PR TITLE
Issue #213. Implemented validation of sending non existing email with request to /email/sendHabitNotification end-point and responding with 404

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
@@ -167,7 +173,11 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -4,6 +4,7 @@ import greencity.constant.HttpStatuses;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.violation.UserViolationMailDto;
+import greencity.exception.handler.ValidationExceptionDto;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
@@ -11,11 +12,17 @@ import greencity.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/email")
@@ -71,7 +78,17 @@ public class EmailController {
      * @author Taras Kavkalo
      */
     @PostMapping("/sendHabitNotification")
-    public ResponseEntity<Object> sendHabitNotification(@RequestBody SendHabitNotification sendHabitNotification) {
+    public ResponseEntity<Object> sendHabitNotification(@RequestBody @Valid SendHabitNotification sendHabitNotification,
+                                                        BindingResult bindingResult) {
+
+        if(bindingResult.hasErrors()) {
+
+            List<ValidationExceptionDto> validationExceptionDtoList = new ArrayList<>();
+            bindingResult.getFieldErrors().forEach(err->validationExceptionDtoList
+                    .add(new ValidationExceptionDto(err)));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationExceptionDtoList);
+        }
+
         emailService.sendHabitNotification(sendHabitNotification.getName(), sendHabitNotification.getEmail());
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -9,6 +9,7 @@ import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
 import greencity.service.EmailService;
+import greencity.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -31,6 +32,9 @@ import java.util.List;
 public class EmailController {
     @Autowired
     private final EmailService emailService;
+
+    @Autowired
+    private final UserService userService;
 
     /**
      * Method for sending news for users who subscribed for updates.
@@ -90,9 +94,13 @@ public class EmailController {
                     .add(new ValidationExceptionDto(err)));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationExceptionDtoList);
         }
-
-        if(principal== null){
+        if(principal==null){
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Please log in to proceed !");
+        }
+
+        if(userService.findByEmail(sendHabitNotification.getEmail()) == null){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User with email: "+
+                    sendHabitNotification.getEmail()+" is not found!");
         }
 
         emailService.sendHabitNotification(sendHabitNotification.getName(), sendHabitNotification.getEmail());

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -79,7 +80,8 @@ public class EmailController {
      */
     @PostMapping("/sendHabitNotification")
     public ResponseEntity<Object> sendHabitNotification(@RequestBody @Valid SendHabitNotification sendHabitNotification,
-                                                        BindingResult bindingResult) {
+                                                        BindingResult bindingResult,
+                                                        Principal principal) {
 
         if(bindingResult.hasErrors()) {
 
@@ -87,6 +89,10 @@ public class EmailController {
             bindingResult.getFieldErrors().forEach(err->validationExceptionDtoList
                     .add(new ValidationExceptionDto(err)));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationExceptionDtoList);
+        }
+
+        if(principal== null){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Please log in to proceed !");
         }
 
         emailService.sendHabitNotification(sendHabitNotification.getName(), sendHabitNotification.getEmail());

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -412,7 +412,11 @@ public class UserController {
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })
     @GetMapping("/findByEmail")
-    public ResponseEntity<UserVO> findByEmail(@RequestParam String email) {
+    public ResponseEntity<?> findByEmail(@RequestParam  String email) {
+
+        if (!email.matches("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Your entered email has invalid format!");
+        }
         return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
     }
 

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -414,10 +414,16 @@ public class UserController {
     @GetMapping("/findByEmail")
     public ResponseEntity<?> findByEmail(@RequestParam  String email) {
 
+        // # issue 274, returning bad request in case of malformed email
         if (!email.matches("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Your entered email has invalid format!");
         }
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
+        // #issue 27, returning status 404 in case of having not found a user with a given email
+        UserVO foundUserV0 = userService.findByEmail(email);
+        if(foundUserV0 == null){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User with email: "+email+" does not exist !");
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(foundUserV0);
     }
 
     /**

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import java.security.Principal;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -142,9 +143,12 @@ class EmailControllerTest {
     })
     void sendHabitNotification(String name, String email, int expectedStatus) throws Exception {
 
+        Principal principal = ()->"test111@gmail.com";
+
         String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
 
         mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .principal(principal)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().is(expectedStatus))
@@ -154,6 +158,33 @@ class EmailControllerTest {
             verify(emailService, times(1)).sendHabitNotification(name, email);
         else
             verify(emailService, times(0)).sendHabitNotification(anyString(), anyString());
+    }
+
+    @Test
+    void sendHabitNotificationAuthenticationReturns401() throws Exception {
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", "Luis", "louis@gmail.com");
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    @Test
+    void sendHabitNotificationAuthenticationReturns200() throws Exception {
+
+        Principal principal = ()->"test111@gmail.com";
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", "Luis", "louis@gmail.com");
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andDo(print());
     }
 
 

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -14,6 +14,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,9 +23,12 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -124,6 +129,33 @@ class EmailControllerTest {
 
         verify(emailService).sendHabitNotification(notification.getName(), notification.getEmail());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Joe Doe, Test1@gmail.com, 200",
+            "'','',400",
+            "1111, validemail@gmail.com, 400",
+             "Joe, Test1@mail..com, 400",
+            "1111, Test1mail.com, 400",
+            "'', Test1@gmail.com, 400",
+            "Joe Doe, '', 400"
+    })
+    void sendHabitNotification(String name, String email, int expectedStatus) throws Exception {
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().is(expectedStatus))
+                .andDo(print());
+
+        if(expectedStatus == 200)
+            verify(emailService, times(1)).sendHabitNotification(name, email);
+        else
+            verify(emailService, times(0)).sendHabitNotification(anyString(), anyString());
+    }
+
 
     private void mockPerform(String content, String subLink) throws Exception {
         mockMvc.perform(post(LINK + subLink)

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.notification.NotificationDto;
+import greencity.dto.user.UserVO;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
 import greencity.service.EmailService;
+import greencity.service.UserService;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,9 +27,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.security.Principal;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,6 +36,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class EmailControllerTest {
     private static final String LINK = "/email";
     private MockMvc mockMvc;
+
+    @Mock
+    private UserService userService;
 
     @Mock
     private EmailService emailService;
@@ -173,18 +176,51 @@ class EmailControllerTest {
     }
 
     @Test
-    void sendHabitNotificationAuthenticationReturns200() throws Exception {
+    void sendHabitNotificationAuthenticationReturns200WhenAuthenticatedAndEmailFound() throws Exception {
 
         Principal principal = ()->"test111@gmail.com";
 
-        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", "Luis", "louis@gmail.com");
+        String name= "Louis";
+        String email= "louis@gmail.com";
+
+        UserVO userVO = new UserVO();
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
+
+        when(userService.findByEmail(email)).thenReturn(userVO);
+
+       doNothing().when(emailService).sendHabitNotification(name, email);
 
         mockMvc.perform(post(LINK + "/sendHabitNotification")
                         .principal(principal)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(print());
+
+        verify(emailService, times(1)).sendHabitNotification(name, email);
+    }
+
+
+    @Test
+    void sendHabitNotificationAuthenticationReturns404WhenAuthenticatedButEmailNotFound() throws Exception {
+
+        Principal principal = ()->"test111@gmail.com";
+        String name= "Louis";
+        String email= "louis@gmail.com";
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isNotFound())
+                .andDo(print());
+
+        verify(emailService, times(0)).sendHabitNotification(name, email);
+
     }
 
 

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -406,6 +406,18 @@ class UserControllerTest {
     }
 
     @Test
+    void findByEmailTestReturns404() throws Exception {
+
+        String notExistedEmail="124125@gmail.com";
+
+        mockMvc.perform(get(userLink + "/findByEmail")
+                        .param("email", notExistedEmail))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+
+    }
+
+    @Test
     void findByIdTest() throws Exception {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findById(1L)).thenReturn(userVO);

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -57,13 +57,16 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -391,6 +394,18 @@ class UserControllerTest {
     }
 
     @Test
+    void findByEmailTestReturns400() throws Exception {
+
+        String malformedEmail="124125gmail.com";
+
+        mockMvc.perform(get(userLink + "/findByEmail")
+                        .param("email", malformedEmail))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+    }
+
+    @Test
     void findByIdTest() throws Exception {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findById(1L)).thenReturn(userVO);
@@ -470,7 +485,7 @@ class UserControllerTest {
             .principal(principal)
             .content(objectMapper.writeValueAsString(ModelUtils.getUserVO())))
             .andExpect(status().isOk())
-            .andDo(MockMvcResultHandlers.print())
+            .andDo(print())
             .andExpect(jsonPath("$.uuid").value("testUuid"));
 
     }

--- a/service-api/src/main/java/greencity/message/SendHabitNotification.java
+++ b/service-api/src/main/java/greencity/message/SendHabitNotification.java
@@ -1,6 +1,9 @@
 package greencity.message;
 
 import java.io.Serializable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +17,12 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SendHabitNotification implements Serializable {
+
+    @NotBlank(message = "Name must not be blank")
+    @Pattern(regexp = "^[a-zA-Z ]+$", message = "Name must contain only alphabetic characters and spaces")
     private String name;
+
+    @Email(message = "Email must have a correct format")
+    @NotBlank(message = "Email must not be blank")
     private String email;
 }


### PR DESCRIPTION
Issue #213. Implemented validation of sending non existing email with request to /email/sendHabitNotification end-point and responding with 404 with tests being made as well. One test, returning 404, was slightly modified

Link to an issue: https://github.com/Board-Project-Stage/ProjectStage_January/issues/213
<img width="1269" alt="Screenshot 2025-01-18 at 17 34 54" src="https://github.com/user-attachments/assets/e2eb86f9-d862-481a-98bb-8ba084889bc2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email notification validation with new constraints
	- Added support for parameterized testing

- **Bug Fixes**
	- Improved error handling for email-related operations
	- Added input validation for user and email controllers

- **Tests**
	- Expanded test coverage for email and user controller functionality
	- Added comprehensive test scenarios for authentication and validation

- **Chores**
	- Removed commons-validator library dependency
	- Added JUnit Jupiter parameters dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->