### PR TITLE
Issue #354 resolved and only current user can access user/{userId}/profileStatistics/ otherwise returns 403 Forbidden

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
@@ -167,7 +173,11 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -4,6 +4,7 @@ import greencity.constant.HttpStatuses;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.violation.UserViolationMailDto;
+import greencity.exception.handler.ValidationExceptionDto;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
@@ -11,11 +12,17 @@ import greencity.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/email")
@@ -71,7 +78,17 @@ public class EmailController {
      * @author Taras Kavkalo
      */
     @PostMapping("/sendHabitNotification")
-    public ResponseEntity<Object> sendHabitNotification(@RequestBody SendHabitNotification sendHabitNotification) {
+    public ResponseEntity<Object> sendHabitNotification(@RequestBody @Valid SendHabitNotification sendHabitNotification,
+                                                        BindingResult bindingResult) {
+
+        if(bindingResult.hasErrors()) {
+
+            List<ValidationExceptionDto> validationExceptionDtoList = new ArrayList<>();
+            bindingResult.getFieldErrors().forEach(err->validationExceptionDtoList
+                    .add(new ValidationExceptionDto(err)));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationExceptionDtoList);
+        }
+
         emailService.sendHabitNotification(sendHabitNotification.getName(), sendHabitNotification.getEmail());
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -412,7 +412,11 @@ public class UserController {
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })
     @GetMapping("/findByEmail")
-    public ResponseEntity<UserVO> findByEmail(@RequestParam String email) {
+    public ResponseEntity<?> findByEmail(@RequestParam  String email) {
+
+        if (!email.matches("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Your entered email has invalid format!");
+        }
         return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
     }
 

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -414,10 +414,16 @@ public class UserController {
     @GetMapping("/findByEmail")
     public ResponseEntity<?> findByEmail(@RequestParam  String email) {
 
+        // # issue 274, returning bad request in case of malformed email
         if (!email.matches("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Your entered email has invalid format!");
         }
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
+        // #issue 27, returning status 404 in case of having not found a user with a given email
+        UserVO foundUserV0 = userService.findByEmail(email);
+        if(foundUserV0 == null){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User with email: "+email+" does not exist !");
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(foundUserV0);
     }
 
     /**

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -30,10 +30,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 import springfox.documentation.annotations.ApiIgnore;
 import java.security.Principal;
 import java.time.LocalDateTime;
@@ -395,6 +398,16 @@ public class UserController {
     @GetMapping("/{userId}/profileStatistics/")
     public ResponseEntity<UserProfileStatisticsDto> getUserProfileStatistics(
         @Parameter(description = "Id of current user. Cannot be empty.") @PathVariable @CurrentUserId Long userId) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        UserVO user = userService.findByEmail(email);
+
+        if (user == null || !user.getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+
         return ResponseEntity.status(HttpStatus.OK)
             .body(userService.getUserProfileStatistics(userId));
     }

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -14,6 +14,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,9 +23,12 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -124,6 +129,33 @@ class EmailControllerTest {
 
         verify(emailService).sendHabitNotification(notification.getName(), notification.getEmail());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Joe Doe, Test1@gmail.com, 200",
+            "'','',400",
+            "1111, validemail@gmail.com, 400",
+             "Joe, Test1@mail..com, 400",
+            "1111, Test1mail.com, 400",
+            "'', Test1@gmail.com, 400",
+            "Joe Doe, '', 400"
+    })
+    void sendHabitNotification(String name, String email, int expectedStatus) throws Exception {
+
+        String requestBody = String.format("{\"name\":\"%s\",\"email\":\"%s\"}", name, email);
+
+        mockMvc.perform(post(LINK + "/sendHabitNotification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().is(expectedStatus))
+                .andDo(print());
+
+        if(expectedStatus == 200)
+            verify(emailService, times(1)).sendHabitNotification(name, email);
+        else
+            verify(emailService, times(0)).sendHabitNotification(anyString(), anyString());
+    }
+
 
     private void mockPerform(String content, String subLink) throws Exception {
         mockMvc.perform(post(LINK + subLink)

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -12,13 +12,7 @@ import greencity.dto.PageableAdvancedDto;
 import greencity.dto.filter.FilterUserDto;
 import greencity.dto.language.LanguageVO;
 import greencity.dto.ubs.UbsTableCreationDto;
-import greencity.dto.user.UserManagementUpdateDto;
-import greencity.dto.user.UserManagementVO;
-import greencity.dto.user.UserManagementViewDto;
-import greencity.dto.user.UserProfileDtoRequest;
-import greencity.dto.user.UserStatusDto;
-import greencity.dto.user.UserUpdateDto;
-import greencity.dto.user.UserVO;
+import greencity.dto.user.*;
 import greencity.enums.EmailNotification;
 import greencity.enums.Role;
 import greencity.repository.UserRepo;
@@ -34,14 +28,14 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -52,6 +46,9 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -618,4 +615,41 @@ class UserControllerTest {
             .andExpect(jsonPath("$.length()").value(3))
             .andExpect(jsonPath("$", Matchers.containsInAnyOrder("Lviv", "Kyiv", "Kharkiv")));
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1, 403",
+            "2, 200"
+    })
+    public void testGetUserProfileStatistics(long id, int expectedStatusCode) throws Exception {
+
+        String email="testuser@domain.com";
+        String name="Joe";
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn(email);
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+
+        UserVO mockUser = new UserVO();
+        mockUser.setId(2L);
+        mockUser.setEmail(email);
+        mockUser.setName(name);
+
+        when(userService.findByEmail(email)).thenReturn(mockUser);
+        when(userService.getUserProfileStatistics(2L)).thenReturn(new UserProfileStatisticsDto());
+
+        mockMvc.perform(get(userLink+"/{userId}/profileStatistics/", id))
+                .andExpect(status().is(expectedStatusCode));
+
+        if(expectedStatusCode == 200)
+            verify(userService, times(1)).getUserProfileStatistics(id);
+        else
+            verify(userService, times(0)).getUserProfileStatistics(id);
+
+    }
+
 }

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -406,6 +406,18 @@ class UserControllerTest {
     }
 
     @Test
+    void findByEmailTestReturns404() throws Exception {
+
+        String notExistedEmail="124125@gmail.com";
+
+        mockMvc.perform(get(userLink + "/findByEmail")
+                        .param("email", notExistedEmail))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+
+    }
+
+    @Test
     void findByIdTest() throws Exception {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findById(1L)).thenReturn(userVO);

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -57,13 +57,16 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -391,6 +394,18 @@ class UserControllerTest {
     }
 
     @Test
+    void findByEmailTestReturns400() throws Exception {
+
+        String malformedEmail="124125gmail.com";
+
+        mockMvc.perform(get(userLink + "/findByEmail")
+                        .param("email", malformedEmail))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+    }
+
+    @Test
     void findByIdTest() throws Exception {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findById(1L)).thenReturn(userVO);
@@ -470,7 +485,7 @@ class UserControllerTest {
             .principal(principal)
             .content(objectMapper.writeValueAsString(ModelUtils.getUserVO())))
             .andExpect(status().isOk())
-            .andDo(MockMvcResultHandlers.print())
+            .andDo(print())
             .andExpect(jsonPath("$.uuid").value("testUuid"));
 
     }

--- a/service-api/src/main/java/greencity/message/SendHabitNotification.java
+++ b/service-api/src/main/java/greencity/message/SendHabitNotification.java
@@ -1,6 +1,9 @@
 package greencity.message;
 
 import java.io.Serializable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +17,12 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SendHabitNotification implements Serializable {
+
+    @NotBlank(message = "Name must not be blank")
+    @Pattern(regexp = "^[a-zA-Z ]+$", message = "Name must contain only alphabetic characters and spaces")
     private String name;
+
+    @Email(message = "Email must have a correct format")
+    @NotBlank(message = "Email must not be blank")
     private String email;
 }


### PR DESCRIPTION
 Issue #354 resolved, now if not a current logged in user tries to access an endpoint user/{userId}/profileStatistics/ returns 403 Forbidden, unit test is also added

Link to issue: https://github.com/Board-Project-Stage/ProjectStage_January/issues/354
<img width="674" alt="Screenshot 2025-01-18 at 20 27 40" src="https://github.com/user-attachments/assets/61d9d3de-d3ef-491b-8249-d34e0e5d0686" />
<img width="910" alt="Screenshot 2025-01-18 at 20 28 23" src="https://github.com/user-attachments/assets/770a0e9e-3847-4a2c-973a-4feb5fd6afe7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced email notification validation with stricter input requirements
  - Improved user profile statistics access controls

- **Bug Fixes**
  - Added robust email format validation
  - Implemented security checks for user data access

- **Tests**
  - Expanded test coverage for email and user-related endpoints
  - Added parameterized testing for various input scenarios

- **Chores**
  - Updated project dependencies
  - Removed unused validator library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->