### PR TITLE
fix/315_Add_403_Forbidden_response_instead_of_401_to_UserController_PATCH_user_status

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,13 +162,26 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package greencity.config;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
+import greencity.exception.handler.CustomAccessDeniedHandler;
 import greencity.security.filters.AccessTokenAuthenticationFilter;
 import greencity.security.jwt.JwtTool;
 import greencity.security.providers.JwtAuthenticationProvider;
@@ -94,8 +95,7 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint((req, resp, exc) -> resp.sendError(
                                 SC_UNAUTHORIZED, "Authorize first."))
-                        .accessDeniedHandler((req, resp, exc) -> resp.sendError(
-                                SC_FORBIDDEN, "You don't have authorities.")))
+                        .accessDeniedHandler(new CustomAccessDeniedHandler()))
                 .authorizeHttpRequests(req -> req
                         .requestMatchers("/static/css/**", "/static/img/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/core/src/main/java/greencity/exception/handler/CustomAccessDeniedHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,17 @@
+package greencity.exception.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write("Access Denied: You do not have permission to access this resource.");
+    }
+}

--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -38,7 +38,8 @@ tokenKey=123123123123123123123123123123123123
 verifyEmailTimeHour=24
 
 # Logger
-logging.level.root=info
+#logging.level.root=info
+logging.level.root=debug
 logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR
 logging.level.greencity.exception.handler.CustomExceptionHandler=trace
 logging.pattern.console=%d{"yyyy/MM/dd HH:mm:ss,SSS"} %magenta([%thread]) %highlight(%-5level) %M\\(%F:%L\\) - %msg%n

--- a/core/src/test/java/greencity/controller/UserControllerSecurityTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerSecurityTest.java
@@ -1,0 +1,66 @@
+package greencity.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import greencity.config.SecurityConfig;
+import greencity.dto.user.UserStatusDto;
+import greencity.enums.UserStatus;
+import greencity.security.jwt.JwtTool;
+import greencity.service.EmailService;
+import greencity.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.security.Principal;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {UserController.class, SecurityConfig.class})
+@WebMvcTest(controllers = UserController.class)
+public class UserControllerSecurityTest {
+    private static final String userLink = "/user";
+    @Autowired
+    private MockMvc mvc;
+    @MockBean
+    private UserService userService;
+    @MockBean
+    private EmailService emailService;
+    @MockBean
+    private JwtTool jwtTool;
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void updateStatusForbiddenTest() throws Exception {
+        UserStatusDto userStatusDto = new UserStatusDto();
+        mvc.perform(patch(userLink + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(userStatusDto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "ADMIN")
+    void updateStatusOkTest() throws Exception {
+        UserStatusDto userStatusDto = new UserStatusDto();
+        userStatusDto.setId(6L);
+        userStatusDto.setUserStatus(UserStatus.CREATED);
+
+        when(userService.updateStatus(userStatusDto.getId(), userStatusDto.getUserStatus(), "user"))
+                .thenReturn(userStatusDto);
+
+        mvc.perform(patch(userLink + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(userStatusDto)))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
As far as this task is similar to my previous task 279, some of the changes are the same (because I haven't merged the previous PR yet):

- Implemented the CustomAccessDeniedHandler class, and added it to the SecurityConfig class instead of the Handler that was there by default.
- Added 3 dependencies to test Spring Security.
- Wrote 2 tests in the UserControllerSecurityTest class to check the response statuses: 403 for the USER role and 200 for the ADMIN role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced custom access denied handling for improved security management

- **Bug Fixes**
  - None

- **Testing**
  - Added comprehensive security tests for user controller endpoints
  - Enhanced testing dependencies for Spring Boot and Spring Security

- **Configuration**
  - Updated logging level to debug for development environment
  - Refined security configuration with custom access denied handler

- **Dependencies**
  - Added Spring Boot and Spring Security testing libraries
  - Removed JSON path testing library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->